### PR TITLE
fix(app-header): title redirects back to homepage

### DIFF
--- a/source/components/AppHeader.js
+++ b/source/components/AppHeader.js
@@ -52,12 +52,6 @@ class AppHeader extends HTMLElement {
 
     this.shadowRoot.innerHTML = `
             <header>
-                <a href="https://github.com/the132Debuggers/cse110-sp23-the132Debuggers" id="logo">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
-                    </svg>
-
-                </a>
 
                 <h1 id="home-redirect">Wizarding World of Fortune Telling</h1>
 

--- a/source/components/AppHeader.js
+++ b/source/components/AppHeader.js
@@ -1,4 +1,6 @@
 import { normalize } from '../js/utils.js';
+import { navigateTo } from '../js/navigation.js';
+
 
 class AppHeader extends HTMLElement {
   constructor() {
@@ -38,6 +40,10 @@ class AppHeader extends HTMLElement {
                 width: 2rem;
             }
 
+            h1:hover {
+                cursor: pointer;
+            }
+
             @media (min-width: 768px) {
                 header {
                     font-size: 1.25rem;
@@ -52,8 +58,9 @@ class AppHeader extends HTMLElement {
                         <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
                     </svg>
 
-                    <h1>Wizarding World of Fortune Telling</h1>
                 </a>
+
+                <h1 id="home-redirect">Wizarding World of Fortune Telling</h1>
 
                 <div id="settings">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -63,6 +70,10 @@ class AppHeader extends HTMLElement {
             </header>
         `;
 
+    (this.shadowRoot.querySelector("#home-redirect")).addEventListener('click', () => {
+        navigateTo('home');
+    });
+    
     this.shadowRoot.adoptedStyleSheets = [normalize, style];
   }
 }

--- a/source/components/AppHeader.js
+++ b/source/components/AppHeader.js
@@ -1,14 +1,13 @@
 import { normalize } from '../js/utils.js';
 import { navigateTo } from '../js/navigation.js';
 
-
 class AppHeader extends HTMLElement {
-    constructor() {
-        super();
-        this.attachShadow({ mode: 'open' });
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
 
-        const style = new CSSStyleSheet();
-        style.replaceSync(`
+    const style = new CSSStyleSheet();
+    style.replaceSync(`
             header {
                 font-size: 1rem;
                 color: #fff;
@@ -51,7 +50,7 @@ class AppHeader extends HTMLElement {
             }
         `);
 
-        this.shadowRoot.innerHTML = `
+    this.shadowRoot.innerHTML = `
             <header>
                 <a href="https://github.com/the132Debuggers/cse110-sp23-the132Debuggers" id="logo">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -70,12 +69,14 @@ class AppHeader extends HTMLElement {
             </header>
         `;
 
-        (this.shadowRoot.querySelector("#home-redirect")).addEventListener('click', () => {
-            navigateTo('home');
-        });
+    this.shadowRoot
+      .querySelector('#home-redirect')
+      .addEventListener('click', () => {
+        navigateTo('home');
+      });
 
-        this.shadowRoot.adoptedStyleSheets = [normalize, style];
-    }
+    this.shadowRoot.adoptedStyleSheets = [normalize, style];
+  }
 }
 
 export default AppHeader;

--- a/source/components/AppHeader.js
+++ b/source/components/AppHeader.js
@@ -3,12 +3,12 @@ import { navigateTo } from '../js/navigation.js';
 
 
 class AppHeader extends HTMLElement {
-  constructor() {
-    super();
-    this.attachShadow({ mode: 'open' });
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
 
-    const style = new CSSStyleSheet();
-    style.replaceSync(`
+        const style = new CSSStyleSheet();
+        style.replaceSync(`
             header {
                 font-size: 1rem;
                 color: #fff;
@@ -51,7 +51,7 @@ class AppHeader extends HTMLElement {
             }
         `);
 
-    this.shadowRoot.innerHTML = `
+        this.shadowRoot.innerHTML = `
             <header>
                 <a href="https://github.com/the132Debuggers/cse110-sp23-the132Debuggers" id="logo">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -70,12 +70,12 @@ class AppHeader extends HTMLElement {
             </header>
         `;
 
-    (this.shadowRoot.querySelector("#home-redirect")).addEventListener('click', () => {
-        navigateTo('home');
-    });
-    
-    this.shadowRoot.adoptedStyleSheets = [normalize, style];
-  }
+        (this.shadowRoot.querySelector("#home-redirect")).addEventListener('click', () => {
+            navigateTo('home');
+        });
+
+        this.shadowRoot.adoptedStyleSheets = [normalize, style];
+    }
 }
 
 export default AppHeader;


### PR DESCRIPTION
### Tracking Info

Resolves #<issue number>

Make sure your branch name conforms to: `<feature/<username>/<3-4 word description separated by dashes>`. Otherwise, please rename your branch and create a new PR.

### Changes

What changes did you make?

Took title out of the <a href>, changed title style so upon hover, cursor becomes a pointer, added eventlistener('click') for title that navigatesTo('home').

### Testing (ignore if on ui/ux team)

How did you confirm your changes worked? 

I played around with the app.

### Confirmation of Change (ignore if on ui/ux team)

Upload a screenshot or video (preferable a video), if possible. Otherwise, please provide instructions on how to see the change.

TODO...

Fixed functionality of the header. Before hovering and clicking the contact icon and "Wizarding World of Fortune Telling" title will redirect you to team's github page. Now you can still access the contact icon and it will redirect you to our github, but hovering and clicking the title will redirect you to the app's homepage.

TRY: hovering the title will make the cursor a pointer and clicking it will redirect you to the home page.