### PR TITLE
fix(transparency): decreased transparency on sort page

### DIFF
--- a/source/components/SortOrChooseSection.js
+++ b/source/components/SortOrChooseSection.js
@@ -39,7 +39,7 @@ class SortOrChooseSection extends HTMLElement {
 
       .option h1 {
         font-size: 1.5rem;
-        background-color: rgba(0, 0, 0, 0.3);
+        background-color: rgba(0, 0, 0, 0.6);
         padding: 0.5rem 1.5rem;
         border-radius: 0.5rem;
       }

--- a/source/components/SortingHatSection.js
+++ b/source/components/SortingHatSection.js
@@ -48,7 +48,7 @@ class SortingHatSection extends HTMLElement {
       #tip {
         font-size: 2.25rem;
         padding: 0.5rem 1.5rem;
-        background-color: rgba(0, 0, 0, 0.5);
+        background-color: rgba(0, 0, 0, 0.6);
         border-radius: 0.5rem;
         text-align: center;
       }


### PR DESCRIPTION
### Tracking Info

Resolves #96 

### Changes

Decreased the transparency of the SortOrChoose labels.

- TODO

### Testing (ignore if on ui/ux team)

How did you confirm your changes worked? 

- TODO

### Confirmation of Change (ignore if on ui/ux team)

Upload a screenshot or video (preferable a video), if possible. Otherwise, please provide instructions on how to see the change.
<img width="1440" alt="Screenshot 2023-06-10 at 3 02 14 PM" src="https://github.com/the132Debuggers/cse110-sp23-the132Debuggers/assets/64984851/41375a00-a498-4bb4-b9d6-9e6b2fbabacd">

<img width="1440" alt="Screenshot 2023-06-10 at 3 00 59 PM" src="https://github.com/the132Debuggers/cse110-sp23-the132Debuggers/assets/64984851/28f12404-9687-4447-b011-1c3a5da62148">


 
